### PR TITLE
chore: relax gettext dependency to also support ~> 1.0.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -52,7 +52,7 @@ defmodule Doggo.MixProject do
       {:ex_doc, "== 0.38.2", only: :dev, runtime: false},
       {:excoveralls, "== 0.18.5", runtime: false, only: [:test]},
       {:floki, "== 0.38.0", only: :test},
-      {:gettext, "~> 0.20 or ~> 0.26", optional: true},
+      {:gettext, "~> 0.20 or ~> 0.26 or ~> 1.0.0", optional: true},
       {:jason, "== 1.4.4", only: [:dev, :test]},
       {:lazy_html, ">= 0.0.0", only: :test},
       {:makeup_diff, "== 0.1.1", only: :dev},


### PR DESCRIPTION
This PR relaxes the `gettext` dependency to also support `~> 1.0.0`, so that projects that depend on doggo can update `gettext` to `1.0.0`.

https://github.com/elixir-gettext/gettext/blob/main/CHANGELOG.md#v100