### PR TITLE
feat(carousel): implement pagination with colocated hook

### DIFF
--- a/.github/workflows/demo_assets.yml
+++ b/.github/workflows/demo_assets.yml
@@ -37,6 +37,9 @@ jobs:
       - name: Install Dependencies
         run: mix deps.get
         working-directory: ./demo
+      - name: Compile Elixir Application
+        run: mix compile
+        working-directory: ./demo
       - name: Install pnpm
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         with:

--- a/demo/assets/build.mjs
+++ b/demo/assets/build.mjs
@@ -30,8 +30,8 @@ let opts = {
   outdir: "../priv/static/assets",
   plugins: plugins,
   alias: {
-    "phoenix-colocated/doggo": "../_build/dev/phoenix-colocated/doggo"
-  }
+    "phoenix-colocated/doggo": "../_build/dev/phoenix-colocated/doggo",
+  },
 };
 
 if (production) {

--- a/demo/assets/build.mjs
+++ b/demo/assets/build.mjs
@@ -23,12 +23,15 @@ const plugins = [
 
 // Define esbuild options
 let opts = {
-  entryPoints: ["js/app.js"],
+  entryPoints: ["js/app.js", "js/storybook.js"],
   bundle: true,
   logLevel: "info",
   target: "es2017",
   outdir: "../priv/static/assets",
   plugins: plugins,
+  alias: {
+    "phoenix-colocated/doggo": "../_build/dev/phoenix-colocated/doggo"
+  }
 };
 
 if (production) {

--- a/demo/assets/js/storybook.js
+++ b/demo/assets/js/storybook.js
@@ -32,3 +32,11 @@
 //     }
 //   };
 // })();
+
+import { hooks } from "phoenix-colocated/doggo";
+
+(function () {
+  window.storybook = {
+    Hooks: hooks
+  };
+})();

--- a/demo/assets/js/storybook.js
+++ b/demo/assets/js/storybook.js
@@ -37,6 +37,6 @@ import { hooks } from "phoenix-colocated/doggo";
 
 (function () {
   window.storybook = {
-    Hooks: hooks
+    Hooks: hooks,
   };
 })();

--- a/demo/config/config.exs
+++ b/demo/config/config.exs
@@ -26,9 +26,11 @@ config :esbuild,
   version: "0.17.11",
   default: [
     args:
-      ~w(js/app.js js/storybook.js --bundle --target=es2017 --outdir=../priv/static/assets --external:/fonts/* --external:/images/*),
+      ~w(js/app.js js/storybook.js --bundle --target=es2017 --outdir=../priv/static/assets --external:/fonts/* --external:/images/*  --alias:@=.),
     cd: Path.expand("../assets", __DIR__),
-    env: %{"NODE_PATH" => Path.expand("../deps", __DIR__)}
+    env: %{
+      "NODE_PATH" => [Path.expand("../deps", __DIR__), Mix.Project.build_path()]
+    }
   ]
 
 # Configures Elixir's Logger

--- a/demo/config/dev.exs
+++ b/demo/config/dev.exs
@@ -16,7 +16,7 @@ config :demo, DemoWeb.Endpoint,
   secret_key_base:
     "7I09KWxcUUDVCHxt1eWTxz/zRZ4K9839EiL/iutqCNQORX+I2K62EM4/Y8HH+60G",
   watchers: [
-    pnpm: ["build:dev:watch", cd: Path.expand("../assets", __DIR__)]
+    pnpm: ["run", "build:dev:watch", cd: Path.expand("../assets", __DIR__)]
   ]
 
 # ## SSL Support

--- a/lib/doggo/components/carousel.ex
+++ b/lib/doggo/components/carousel.ex
@@ -192,6 +192,7 @@ defmodule Doggo.Components.Carousel do
       data-active-index="0"
       {@data_attrs}
       {@rest}
+      phx-hook=".Carousel"
     >
       <div class={"#{@base_class}-inner"}>
         <div class={"#{@base_class}-controls"}>
@@ -245,6 +246,60 @@ defmodule Doggo.Components.Carousel do
         </div>
       </div>
     </section>
+    <script :type={Phoenix.LiveView.ColocatedHook} name=".Carousel">
+      export default {
+        mounted() {
+          const carousel = this.el;
+          const baseClass = carousel.className.split(' ')[0];
+
+          const prevBtn = carousel.querySelector(`.${baseClass}-previous`);
+          const nextBtn = carousel.querySelector(`.${baseClass}-next`);
+          const tabs = carousel.querySelectorAll('[role="tab"]');
+          const totalItems =
+            carousel.querySelectorAll(`.${baseClass}-item`).length;
+
+          const getCurrentIdx = () =>
+            Number(carousel.getAttribute("data-active-index")) || 0;
+
+          const goTo = (newIdx) => {
+            const wrapAroundIdx = (newIdx + totalItems) % totalItems;
+
+            carousel.setAttribute("data-active-index", wrapAroundIdx);
+
+            tabs.forEach((tab, idx) => {
+              const isSelected = idx === wrapAroundIdx;
+              tab.setAttribute("aria-selected", isSelected ? "true" : "false");
+              tab.setAttribute("tabindex", isSelected ? "0" : "-1");
+            });
+
+            return wrapAroundIdx;
+          };
+
+          if (prevBtn) {
+            prevBtn.addEventListener("click", () => goTo(getCurrentIdx() - 1));
+          }
+          if (nextBtn) {
+            nextBtn.addEventListener("click", () => goTo(getCurrentIdx() + 1));
+          }
+
+          tabs.forEach((tab, idx) => {
+            tab.addEventListener("click", () => goTo(idx));
+
+            tab.addEventListener("keydown", (e) => {
+              if (e.key !== "ArrowRight" && e.key !== "ArrowLeft") return;
+
+              e.preventDefault();
+              const offset = e.key === "ArrowRight" ? 1 : -1;
+              const nextIdx = goTo(getCurrentIdx() + offset);
+
+              if (tabs[nextIdx]) tabs[nextIdx].focus();
+            });
+          });
+
+          goTo(getCurrentIdx());
+        }
+      }
+    </script>
     """
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -23,7 +23,8 @@ defmodule Doggo.MixProject do
       homepage_url: @source_url,
       description: description(),
       package: package(),
-      docs: docs()
+      docs: docs(),
+      compilers: [:phoenix_live_view] ++ Mix.compilers()
     ]
   end
 


### PR DESCRIPTION
Implements carousel pagination using colocated hook, with the necessary configuration updates so that compiles correctly and works in the storybook demo app.

It seems that we may need to allow the active slide to receive focus on tabbing, as shown in this [example](https://www.w3.org/WAI/ARIA/apg/patterns/carousel/examples/carousel-2-tablist/). I can do that in a separate PR.

Also if this approach is acceptable, I can make a separate PR to add play / pause (auto rotation) behavior.