### PR TITLE
Carousel auto rotation

### DIFF
--- a/lib/doggo/components/carousel.ex
+++ b/lib/doggo/components/carousel.ex
@@ -205,6 +205,7 @@ defmodule Doggo.Components.Carousel do
       aria-labelledby={@labelledby}
       aria-roledescription={@carousel_roledescription}
       data-active-index="0"
+      data-auto-rotation={@auto_rotation}
       {@data_attrs}
       {@rest}
       phx-hook=".Hook"
@@ -274,6 +275,11 @@ defmodule Doggo.Components.Carousel do
           const items = carousel.querySelectorAll(`.${baseClass}-item`);
           const totalItems = items.length;
 
+          const isAutoRotationEnabled =
+            carousel.getAttribute("data-auto-rotation") != null;
+          const rotationIntervalMs = 5000;
+          let autoRotationTimer = null;
+
           const getWrappedIndex = (currentIdx, offset) => {
             return (currentIdx + offset + totalItems) % totalItems;
           };
@@ -339,7 +345,31 @@ defmodule Doggo.Components.Carousel do
             });
           });
 
+          // Auto rotation
+          const startAutoRotation = () => {
+            if (!isAutoRotationEnabled || autoRotationTimer != null) return;
+            autoRotationTimer = setInterval(() => {
+              const nextIdx = getWrappedIndex(getCurrentIdx(), 1);
+              scrollToIdx(nextIdx);
+            }, rotationIntervalMs);
+          }
+
+          const stopAutoRotation = () => {
+            if (autoRotationTimer != null) {
+              clearInterval(autoRotationTimer);
+              autoRotationTimer = null;
+            }
+          }
+
+          carousel.addEventListener('mouseenter', stopAutoRotation);
+          carousel.addEventListener('mouseleave', startAutoRotation);
+
+          carousel.addEventListener('focusin', stopAutoRotation);
+          carousel.addEventListener('focusout', startAutoRotation);
+
+          // Initialize
           syncActiveState();
+          startAutoRotation();
         }
       }
     </script>

--- a/lib/doggo/components/carousel.ex
+++ b/lib/doggo/components/carousel.ex
@@ -361,11 +361,9 @@ defmodule Doggo.Components.Carousel do
             }
           }
 
-          carousel.addEventListener('mouseenter', stopAutoRotation);
-          carousel.addEventListener('mouseleave', startAutoRotation);
+          carousel.addEventListener('mouseover', stopAutoRotation);
 
           carousel.addEventListener('focusin', stopAutoRotation);
-          carousel.addEventListener('focusout', startAutoRotation);
 
           // Initialize
           syncActiveState();

--- a/lib/doggo/components/carousel.ex
+++ b/lib/doggo/components/carousel.ex
@@ -262,7 +262,7 @@ defmodule Doggo.Components.Carousel do
         </div>
       </div>
     </section>
-    <script :type={Phoenix.LiveView.ColocatedHook} name=".">
+    <script :type={Phoenix.LiveView.ColocatedHook} name=".Hook">
       export default {
         mounted() {
           const carousel = this.el;

--- a/lib/doggo/storybook/carousel.ex
+++ b/lib/doggo/storybook/carousel.ex
@@ -12,7 +12,7 @@ defmodule Doggo.Storybook.Carousel do
     [
       %Variation{
         id: :default,
-        attributes: %{label: "Our Dogs", pagination: true},
+        attributes: %{label: "Our Dogs", pagination: true, auto_rotation: true},
         slots: slots(opts)
       }
     ]


### PR DESCRIPTION
This builds on top of #688 which introduced scrollable carousels, and implements auto rotation with a default of 5000ms, if the `auto_rotation` attribute is set.

Pauses auto rotation on hover and focus (e.g. in controls).