### PR TITLE
fix(carousel): ensure that items at the edges can be scrolled to the center

### DIFF
--- a/demo/assets/css/components/_carousel.scss
+++ b/demo/assets/css/components/_carousel.scss
@@ -13,15 +13,21 @@
     overflow-x: hidden;
   }
 
-  .carousel-items {
-    display: flex;
-    align-items: center;
-    justify-content: flex-start;
+  .carousel-items-container {
     width: 100%;
-    padding-left: calc(50% - calc(var(--item-width) / 2));
     overflow-x: auto;
     scroll-snap-type: x mandatory;
     scrollbar-width: none;
+  }
+
+  .carousel-items {
+    display: flex;
+    width: fit-content;
+
+    // Provide enough padding on the left and right so that items at the edges can
+    // be scrolled to the center.
+    padding-right: calc(50% - var(--item-width) / 2);
+    padding-left: calc(50% - var(--item-width) / 2);
   }
 
   .carousel-item {

--- a/lib/doggo/components/carousel.ex
+++ b/lib/doggo/components/carousel.ex
@@ -244,20 +244,22 @@ defmodule Doggo.Components.Carousel do
             </div>
           </div>
         </div>
-        <div
-          id={"#{@id}-items"}
-          class={"#{@base_class}-items"}
-          aria-live={if @auto_rotation, do: "off", else: "polite"}
-        >
+        <div class={"#{@base_class}-items-container"}>
           <div
-            :for={{item, index} <- Enum.with_index(@item, 1)}
-            id={"#{@id}-item-#{index}"}
-            class={"#{@base_class}-item"}
-            role="group"
-            aria-roledescription={@slide_roledescription}
-            aria-label={item.label}
+            id={"#{@id}-items"}
+            class={"#{@base_class}-items"}
+            aria-live={if @auto_rotation, do: "off", else: "polite"}
           >
-            {render_slot(item)}
+            <div
+              :for={{item, index} <- Enum.with_index(@item, 1)}
+              id={"#{@id}-item-#{index}"}
+              class={"#{@base_class}-item"}
+              role="group"
+              aria-roledescription={@slide_roledescription}
+              aria-label={item.label}
+            >
+              {render_slot(item)}
+            </div>
           </div>
         </div>
       </div>
@@ -271,7 +273,8 @@ defmodule Doggo.Components.Carousel do
           const prevBtn = carousel.querySelector(`.${baseClass}-previous`);
           const nextBtn = carousel.querySelector(`.${baseClass}-next`);
           const tabs = carousel.querySelectorAll('[role="tab"]');
-          const itemsContainer = carousel.querySelector(`.${baseClass}-items`);
+          const itemsContainer =
+            carousel.querySelector(`.${baseClass}-items-container`);
           const items = carousel.querySelectorAll(`.${baseClass}-item`);
           const totalItems = items.length;
 

--- a/test/doggo/components_test.exs
+++ b/test/doggo/components_test.exs
@@ -867,7 +867,12 @@ defmodule Doggo.ComponentsTest do
       assert attribute(section, "aria-roledescription") == "carousel"
       assert attribute(section, "aria-label") == "Dog Carousel"
 
-      items = find_one(html, ":root > .carousel-inner > .carousel-items")
+      items =
+        find_one(
+          html,
+          ":root > .carousel-inner > .carousel-items-container  > .carousel-items"
+        )
+
       assert attribute(items, "aria-live") == "polite"
 
       div = find_one(items, "> .carousel-item:first-child")
@@ -1019,7 +1024,12 @@ defmodule Doggo.ComponentsTest do
         </TestComponents.carousel>
         """)
 
-      div = find_one(html, ":root > .carousel-inner > .carousel-items")
+      div =
+        find_one(
+          html,
+          ":root > .carousel-inner > .carousel-items-container > .carousel-items"
+        )
+
       assert attribute(div, "aria-live") == "off"
     end
 


### PR DESCRIPTION
Problem:
Items at the edges could not be scrolled into active state - i.e. scrolled to the center.

Fix:
This adds a container for the carousel items, such that sufficient padding can be added on the left and right to fill up the container width. This allows all items to be scrolled to the center to trigger the correct active index.

<img width="1469" height="750" alt="Screenshot 2026-07-10 at 13 16 35" src="https://github.com/user-attachments/assets/f3ca5e04-f905-4365-bb4a-1c940522da21" />
